### PR TITLE
Provide server-logging as a default profile option

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,11 +70,6 @@
       <version>1.1-SNAPSHOT</version>
     </dependency>
     <dependency>
-      <groupId>com.github.susom</groupId>
-      <artifactId>server-logging</artifactId>
-      <version>1.0</version>
-    </dependency>
-    <dependency>
       <groupId>org.checkerframework</groupId>
       <artifactId>checker-qual</artifactId>
       <version>${checkerframework.version}</version>
@@ -266,6 +261,19 @@
   </build>
 
   <profiles>
+    <profile>
+      <id>log4j</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>com.github.susom</groupId>
+          <artifactId>server-logging</artifactId>
+          <version>1.0</version>
+        </dependency>
+      </dependencies>
+    </profile>
     <profile>
       <id>hsql</id>
       <activation>


### PR DESCRIPTION
Downstream projects using vertx-parent are forced to use log4j, as it is a dependency of server-logging, which is a dependency of vertx-parent. This is problematic if your project wants to use a different slf4j facade, such as logback. 

This pull request moves the susom-logging dependency into a profile called "log4j" which is active by default, for backwards compatibility. 
